### PR TITLE
Configure provenance when publishing on npm

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -31,6 +31,6 @@ jobs:
         run: npm version ${GITHUB_REF#refs/tags/} --no-git-tag-version
       - name: Install dependencies
         run: npm i
-      - run: npm publish --access public
+      - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPMJS_TOKEN}}


### PR DESCRIPTION
Add `--provenance` flag to include the provenance of the package source when publishing on npm (built on signed via a GitHub Action). See [:books: Introducing npm package provenance](https://github.blog/security/supply-chain-security/introducing-npm-package-provenance/).